### PR TITLE
force utf-8 when writing XML

### DIFF
--- a/fixup_shaper_svg.py
+++ b/fixup_shaper_svg.py
@@ -61,13 +61,14 @@ def fixup_svg(infile, outfile):
     svg = xml.etree.ElementTree.parse(infile)
     for elem in svg.iter():
         fixup_element(elem)
-    svg.write(outfile, encoding='unicode', xml_declaration=True)
+    encoding = 'unicode' if outfile == sys.stdout else 'utf-8'
+    svg.write(outfile, encoding=encoding, xml_declaration=True)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('infile', nargs='?', type=argparse.FileType('r'), default=sys.stdin)
-    parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'), default=sys.stdout)
+    parser.add_argument('outfile', nargs='?', type=argparse.FileType('wb'), default=sys.stdout)
     args = parser.parse_args()
 
     fixup_svg(infile=args.infile, outfile=args.outfile)

--- a/fixup_shaper_svg_tests.py
+++ b/fixup_shaper_svg_tests.py
@@ -1,6 +1,7 @@
 import unittest
+import io
 
-from fixup_shaper_svg import length_value_without_spaces, style_attribute_without_fill_rule
+from fixup_shaper_svg import fixup_svg, length_value_without_spaces, style_attribute_without_fill_rule
 
 
 class LengthWithUnit(unittest.TestCase):
@@ -40,6 +41,17 @@ class StyleWithUnsupportedAttributes(unittest.TestCase):
                          style_attribute_without_fill_rule("  fill-rule: evenodd;fill:  none  ;  "))
         self.assertEqual("",
                          style_attribute_without_fill_rule(" fill-rule: evenodd; "))
+
+
+class XmlFileEncoding(unittest.TestCase):
+
+    def test_does_force_utf8(self):
+        infile = io.StringIO("""<?xml version='1.0' encoding='cp1252'?>
+<svg xmlns="http://www.w3.org/2000/svg"/>""")
+        with io.BytesIO() as outfile:
+            fixup_svg(infile, outfile)
+            self.assertEqual(b'<?xml version=\'1.0\' encoding=\'utf-8\'?>\n'
+                             b'<svg xmlns="http://www.w3.org/2000/svg" />', outfile.getvalue())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Output encoding now `utf-8` when writing to files (and `unicode` when writing to `stdout`).

This should fix the issue on Windows where `unicode` seemingly defaults to `cp1252` as seen in #2 .

Fixes #2 

## Test Plan
Testing assets from #2 on Jenner (3.7.20.0) and macOS Sonoma (14.4.1) using Python3 (3.11.5)

![CleanShot 2024-04-21 at 18 39 04](https://github.com/HBehrens/fixup_shaper_svg/assets/486904/2edc6bab-ea37-4dcd-8b62-21051df052c9)

1. original file renders correct preview
2. output before this change has no preview
3. manually edited output as documented in #2 renders correctly
4. output after this change has correct preview

Also confirming that when trying to place the design on a workspace, ❶ is leading to an error whereas ❹ works as expected.